### PR TITLE
Fix broken link / add link to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # R_for_Statistics
+
 Material supporting my Introduction to R and RStudio for Statistics Course
+
+* [georgemsavva.github.io/R_for_Statistics](https://georgemsavva.github.io/R_for_Statistics/index.html)

--- a/docs/index.html
+++ b/docs/index.html
@@ -340,7 +340,7 @@ $(document).ready(function () {
 </ul></li>
 <li>Notes on using R
 <ul>
-<li><a href="./datatabletidyverse.Rmd">Tidyverse, data.table and others for making descriptive tables</a></li>
+<li><a href="./datatabletidyverse.html">Tidyverse, data.table and others for making descriptive tables</a></li>
 </ul></li>
 </ul>
 


### PR DESCRIPTION
Currently the link to [Tidyverse, data.table and others for making descriptive tables](https://georgemsavva.github.io/R_for_Statistics/datatabletidyverse.Rmd) from [https://georgemsavva.github.io/R_for_Statistics/index.html](https://georgemsavva.github.io/R_for_Statistics/index.html) is not working